### PR TITLE
Added a function to create a "Heat Map" for the mean particle density, and fixed some minor bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.asv
+*.mat
+*.avi
+*.csv
+*.jpg
+*.rar

--- a/MDSim.m
+++ b/MDSim.m
@@ -25,7 +25,7 @@ else
     end
 end
 %% Saving the configuration
-save(strcat(cfg.saveFoldername, '/cfg.m'), 'cfg');
+save(strcat(cfg.saveFoldername, '/cfg.mat'), 'cfg');
 %% Setting up the run variables
 currStepData = simStepData;
 currStepData.particlePositions = (squeeze(particlePositions(1,:,:)));
@@ -39,9 +39,9 @@ currStepData.wallPositionsY = wallPositionsY;
     pause(0.01);
 %% Checking whether to run hydrosynamic interactions
 if ~cfg.useHydro
-    Dx = ones(1, numOfParticles).*D;
+    Dx = ones(cfg.numOfParticles,1).*D;
     Dy = Dx;
-    Ax = ones(1, numOfParticles).*sqrt(2*D);
+    Ax = ones(cfg.numOfParticles,1).*sqrt(2*D);
     Ay = Ax;
 end
 %% Running the simulation
@@ -62,7 +62,8 @@ for i = 2:1:cfg.N
         sampleInd = sampleInd + 1;
     end
     %% Saving the steps according to the save period parameter
-    if mod(i, cfg.savePeriod) == 0
+    if mod(i, cfg.savePeriod) == 0 || i == cfg.N
+        %% Saving the latest particle positions in .csv files
         dlmwrite(strcat(cfg.saveFoldername, '/pos_x.csv'),...
                     particlePositions(1:sampleInd-1,:,1),...
                     '-append');
@@ -70,10 +71,11 @@ for i = 2:1:cfg.N
                     particlePositions(1:sampleInd-1,:,2),...
                     '-append');
         particlePositions(1:sampleInd-1,:,:) = 0;
-        if exist(strcat(cfg.saveFoldername, '/data.m'), 'file')
-            delete(strcat(cfg.saveFoldername, '/data.m'));
+        %% Saving the additional tracked data in a .mat file.
+        if exist(strcat(cfg.saveFoldername, '/data.mat'), 'file')
+            delete(strcat(cfg.saveFoldername, '/data.mat'));
         end
-        save(strcat(cfg.saveFoldername, '/data.m'), 'addedData');
+        save(strcat(cfg.saveFoldername, '/data.mat'), 'addedData');
         sampleInd = 1;
     end
     %% Forces computation

--- a/Utility/densityHeatMap.m
+++ b/Utility/densityHeatMap.m
@@ -1,0 +1,81 @@
+function [meanDensitiy, densitySTDs] = densityHeatMap(particlePositions, radii, xLimits, yLimits, pixelsPerLength, verbose, movie, saveFoldername)
+% DENSITYHEATMAP  Generates a heat map of the densities of particles given
+% their tracks
+%   particlePositions:  The tracks of the particles used (numOfFrames,
+%   numOfParticles, numOfDimensions)
+%   radii: A vector containing the radii of the particles
+%   xLimits, yLimits: The range in which to check the density (each is a
+%   two-value vector of the lower and upper bounds)
+%   pixelsPerLength: Determines how many pixels (matrix cells) would be
+%   generated per length unit in the tracks (coarse-graining)
+%   verbose: A boolean detemining whether to show the heat map being
+%   generated live
+%   movie: A boolean determining whether to save a movie of the evolution
+%   of the heat map
+%   saveFoldername: The folder in which to save the STD data, and the movie
+%   if needed
+
+    lx = abs(xLimits(2) - xLimits(1));
+    ly = abs(yLimits(2) - yLimits(1));
+    numOfFrames = size(particlePositions,1);
+    numOfParticles = size(particlePositions, 2);
+    
+    % Creating a coarse-grained matrix of the tested area
+    nx = pixelsPerLength.*lx;
+    ny = pixelsPerLength.*ly;
+    meanDensitiy = zeros(ny, nx);
+    % Note that since these are images, we use the rows for the y axis and
+    % the columns for the x axis, opposite from what the simulation uses.
+    
+    densitySTDs = zeros(numOfFrames, 1);
+    radiiInMat = radii.*pixelsPerLength;
+    for frameInd = 1:numOfFrames
+        for particleInd = 1:numOfParticles
+            currPosition = squeeze(particlePositions(frameInd,particleInd,:));
+            % Getting the center in of the particle in the coarse-grained
+            % matrix
+            positionInMat = [(currPosition(1) - xLimits(1)) .* pixelsPerLength,
+                             (currPosition(2) - yLimits(1)) .* pixelsPerLength];
+            % Finding the points in which the particle is present (a circle
+            % of radius R around the center of the particle)
+            cellsToRaise = getCirclePart(nx,ny,...
+                                         positionInMat(1),positionInMat(2),...
+                                         0, radiiInMat(particleInd),...
+                                         0,2*pi);
+            % Raising the intensity in the coarse grained matrix at the
+            % points in which the particle is present.
+            meanDensitiy(cellsToRaise) = meanDensitiy(cellsToRaise) + 1;
+        end
+        
+        % Measuring the standard deviation of the mean intensity
+        % distribition of all steps up to the current one. (The division by
+        % the frame index is essentially normalization)
+        densitySTDs(frameInd) = std(meanDensitiy(:) ./ frameInd);
+        
+        % Checking whether to show the data on screen
+        if verbose || movie
+            imagesc(meanDensitiy ./ frameInd);
+            set(gca,'YDir','normal');
+            title(frameInd);
+            if movie
+                % Note that F is not pre-allocated, since matlab forbids
+                % pre-allocation of very large matrices
+                F(frameInd) = getframe(gcf);
+                drawnow
+            end
+        end
+        pause(0.001);
+    end
+    % Saving the movie to the disk, if needed
+    if movie
+        saveMovie(F, 60, strcat(saveFoldername, '/heatMap.avi'));
+    end
+    % Saving the vector of density standard deviations
+    save(strcat(saveFoldername, '/densitySTDs.mat'),'densitySTDs');
+    % Presenting the plot of the standard deviation of the mean particle
+    % density
+    figure
+    plot(densitySTDs);
+    xlabel('Number of steps');
+    ylabel('Standard Deviation');
+    title(strcat('Standard Deviation of the mean particle density', saveFoldername));

--- a/Utility/getCirclePart.m
+++ b/Utility/getCirclePart.m
@@ -1,0 +1,27 @@
+function relPoints = getCirclePart(nx, ny, xCenter, yCenter,rhoMin, rhoMax, minPhi, maxPhi)
+% GETCIRCLEPART  Finds and returns the indices of points in a matrix
+% corresponding to a desired part of a circle around a central position
+%   nx, ny:  The x and y dimensions of the matrix for which the indices are
+%   needed
+%   xCenter, yCenter: The coordinates of the central position of the
+%   particle
+%   rhoMin, rhoMax: The minimum and maximum radii from the center for which
+%   to include points
+%   minPhi, maxPhi: The minimum and maximum angles (in radians) for which
+%   to include points
+
+[X,Y]=meshgrid(1:nx,1:ny);
+c = [xCenter, yCenter];
+angle = mod(atan2(Y-c(2),X-c(1)),2*pi);
+minPhi = wrapTo2Pi(minPhi);
+maxPhi = wrapTo2Pi(maxPhi);
+
+% Checking which part of the circle to return (the smaller or larger part
+% defined by the two angles)
+if maxPhi > minPhi
+    relPoints=  ((sqrt((X-c(1)).^2+(Y-c(2)).^2) >= rhoMin) & (sqrt((X-c(1)).^2+(Y-c(2)).^2) <= rhoMax)) & ...
+                ((angle > minPhi) & (angle < maxPhi));
+else
+    relPoints=  ((sqrt((X-c(1)).^2+(Y-c(2)).^2) >= rhoMin) & (sqrt((X-c(1)).^2+(Y-c(2)).^2) <= rhoMax)) & ...
+                ((angle > minPhi) | (angle < maxPhi));    
+end

--- a/Utility/saveMovie.m
+++ b/Utility/saveMovie.m
@@ -1,0 +1,15 @@
+function saveMovie(frames, frameRate, filename)
+    % create the video writer with 1 fps
+    writerObj = VideoWriter(filename);
+    writerObj.FrameRate = frameRate;
+    % set the seconds per image
+    % open the video writer
+    open(writerObj);
+    % write the frames to the video
+    for i=1:length(frames)
+        % convert the image to a frame
+        frame = frames(i) ;    
+        writeVideo(writerObj, frame);
+    end
+    % close the writer object
+    close(writerObj);

--- a/infoChamber.m
+++ b/infoChamber.m
@@ -34,7 +34,12 @@ function particlePositions = infoChamber(N,Dt,sampleRate,R,T,eta, lx, ly, numOfP
     initPositions(2,:) = particlesY;
     cfg.initPositions = initPositions;
     %% Running the simulation
-    particlePositions = MDSim(cfg, @computeForces, @checkIfMoveWall, @moveWall, @printCurrStep, wallData);
+    particlePositions = MDSim(cfg, @computeForces, @(x,y,z) false, @moveWall, @printCurrStep, wallData);
+    %% Checking the mean densities
+    pixelsPerLength = 10/1e-6
+    densityHeatMap(particlePositions, cfg.R,...
+                   cfg.wallPositionsX, cfg.wallPositionsY,...
+                   pixelsPerLength, true, true, cfg.saveFoldername);
     %% Showing the results
     wallData.wallMoveSteps = wallData.wallMoveSteps(wallData.wallMoveSteps ~= 0);
     wallData.newWallPositions = wallData.newWallPositions(wallData.newWallPositions ~= 0);
@@ -72,23 +77,24 @@ function particlePositions = infoChamber(N,Dt,sampleRate,R,T,eta, lx, ly, numOfP
                     particlePositions(i,:,2)'],...
             ones(numOfParticles,1).*cfg.R(1));
         hold off
-          F(i) = getframe(gcf) ;
+          F(i) = getframe(gcf);
           drawnow
         if movedInd < length(sampledWallMoves) && mod(i,sampledWallMoves(movedInd)) == 0
             movedInd = movedInd + 1;
         end
     end
-    % create the video writer with 1 fps
-    writerObj = VideoWriter(strcat(cfg.saveFoldername, '/movie.avi'));
-    writerObj.FrameRate = sampleRate;
-    % set the seconds per image
-    % open the video writer
-    open(writerObj);
-    % write the frames to the video
-    for i=1:length(F)
-        % convert the image to a frame
-        frame = F(i) ;    
-        writeVideo(writerObj, frame);
-    end
-    % close the writer object
-    close(writerObj);
+    saveMovie(F, 1/cfg.sampleRate, strcat(cfg.saveFoldername, '/movie.avi'))
+%     % create the video writer with 1 fps
+%     writerObj = VideoWriter(strcat(cfg.saveFoldername, '/movie.avi'));
+%     writerObj.FrameRate = sampleRate;
+%     % set the seconds per image
+%     % open the video writer
+%     open(writerObj);
+%     % write the frames to the video
+%     for i=1:length(F)
+%         % convert the image to a frame
+%         frame = F(i) ;    
+%         writeVideo(writerObj, frame);
+%     end
+%     % close the writer object
+%     close(writerObj);


### PR DESCRIPTION
In order to estimate the time it takes for particles to reach equilibrium, it is useful to create a "Heat Map" of the mean particle densities as the simulation progresses. For instance:
![image](https://user-images.githubusercontent.com/51112646/79378636-5359b080-7f66-11ea-9a2c-768429789333.png)
![image](https://user-images.githubusercontent.com/51112646/79378558-3ae99600-7f66-11ea-9398-943dd16e243d.png)
![image](https://user-images.githubusercontent.com/51112646/79378596-450b9480-7f66-11ea-8665-4471d92b901f.png)

The function added for this purpose can save a movie of the heat map's evolution, if desired, and returns the final mean density matrix along with a vector of the standard deviation of the "intensity" of the mean density. The standard deviation may be a good analog to a correlation function, insofar as it allows one to quantify the time needed for the system to erase initial conditions, or other words - the length of the system's memory.