### PR TITLE
Fixed the bug with the hydrodynamic interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.rar
 *.png
 *.sfit
+MSD.m

--- a/infoChamber.m
+++ b/infoChamber.m
@@ -1,4 +1,6 @@
 function particlePositions = infoChamber(N,Dt,sampleRate,R,T,eta, lx, ly, numOfParticles, wallShrink,saveFoldername, displayLive)
+    tic
+    startTime = toc;
     %% Setting the configuration for the simulation
     cfg = simConfig;
     cfg.N = N;
@@ -13,7 +15,7 @@ function particlePositions = infoChamber(N,Dt,sampleRate,R,T,eta, lx, ly, numOfP
     cfg.xlimits=cfg.wallPositionsX.*1.1;
     cfg.ylimits=cfg.wallPositionsY*1.1;
     cfg.useWalls = true;
-    cfg.wallRepulsionType = 'Harmonic';
+    cfg.wallRepulsionType = 'WCA';
     cfg.wallHarmonicK = 2e6*physconst('boltzmann')*cfg.T./1e-6;
 %     cfg.wallGaussianA = 1e3*physconst('boltzmann')*cfg.T;
 %     cfg.wallGaussianS = 10e-6;
@@ -52,5 +54,6 @@ function particlePositions = infoChamber(N,Dt,sampleRate,R,T,eta, lx, ly, numOfP
     %% Running the simulation
     particlePositions = MDSim(cfg, @computeForces, @(x,y,z) false, @moveWall, @printCurrStep, wallData);
     
+    totalTime = toc - startTime
     %% Running the post-simulation analysis
-    postSimAnalysis(cfg, wallData);
+%     postSimAnalysis(cfg, wallData);

--- a/rotnePrager.m
+++ b/rotnePrager.m
@@ -1,3 +1,4 @@
+% The computation follows the method presented in Nagar & Roichman (2018)
 function DMat = rotnePrager(particlesMat,R, D)
 d = 2; % The dimension of the problem. 
 % The code is NOT scalable to more or less dimensions, the variable d is
@@ -6,17 +7,10 @@ d = 2; % The dimension of the problem.
 % Converting the matrix of particle positions into a vector of the form
 % (x1, y1, x2, y2,..., xn, yn)
 numOfParticles = size(particlesMat,1);
-workingMat = particlesMat';
-particlesVec = zeros(d*numOfParticles,1);
-for i = 1:numOfParticles
-    particlesVec(2*i-1) = workingMat(1,i);
-    particlesVec(2*i) = workingMat(2,i);
-end
 
 % Constants for the matrix values
 c1 = 0.75*R;
 c2 = 0.5*R^3;
-
 % Setting a unit matrix to start from
 DMat = eye(d*numOfParticles);
 
@@ -33,7 +27,7 @@ for checkedParticle = 1:numOfParticles
         yDiff = particlesMat(checkedParticle,2) - particlesMat(pairedParticle,2);
         r = sqrt(xDiff^2+yDiff^2);
         
-        % For the x-x matrix position, adding c1(1 + x^2/r^2)
+        % For the x-x matrix position, setting (c1/r)(1 + x^2/r^2) + (c2/pow(r,3))(1 - 3*(x^2/r^2))
         DMat(xxPosition(1),xxPosition(2)) = (c1./r).*(1 + xDiff^2/r^2) +...
                                             (c2 ./ r^3).*(1-(xDiff^2/r^2));
         


### PR DESCRIPTION
The computation of random brownian motion with hydrodynamic interactions was wrong and made the particles diffuse more quickly as their numbers increased (Whichever was first in the array moved the slowest, and the last moved the fastet)
This was the result of wrong usage of the result of the Cholesky decomposition. More info can be found here: https://stats.stackexchange.com/questions/83850/confused-about-cholesky-and-eigen-decomposition